### PR TITLE
Adjudication Methods

### DIFF
--- a/server/Adjudication/Evaluation/MovementEvaluator.cs
+++ b/server/Adjudication/Evaluation/MovementEvaluator.cs
@@ -1,4 +1,5 @@
 ﻿using Entities;
+using Enums;
 
 namespace Adjudication;
 

--- a/server/Adjudication/Evaluation/MovementEvaluator.cs
+++ b/server/Adjudication/Evaluation/MovementEvaluator.cs
@@ -23,20 +23,40 @@ public class MovementEvaluator(World world, List<Order> activeOrders, AdjacencyV
         // - Mark units needing retreat or add disbands if not possible (use adjacencyValidator)
     }
 
+    public void AdjudicateConvoy(Convoy convoy)
+    {
+        bool unresolved = false;
+        foreach (Move attackingMove in support.Location.AttackingMoves)
+        {
+            if (attackingMove.Status = Enums.OrderStatus.Success)
+            {
+                convoy.Status = Enums.OrderStatus.Failure;
+            }
+            else if (attackingMove.Status != Enums.OrderStatus.Failure)
+            {
+                unresolved = true;
+            }
+        }
+        if (!unresolved)
+        {
+            support.Status = Enums.OrderStatus.Success;
+        }
+    }
+
     public void AdjudicateSupport(Support support)
     {
         bool unresolved = false;
-        foreach (var attackingMove in support.Location.AttackingMoves)
+        foreach (Move attackingMove in support.Location.AttackingMoves)
         {
             if (!Object.ReferenceEquals(support.Midpoint,support.Destination) && !Object.ReferenceEquals(support.Destination, attackingMove.Location))
             {
-                //TODO - also need to check if it's an unresolved convoy move first... If so the support should also be unresolved.
                 support.Status = Enums.OrderStatus.Failure;
             }
             else
             {
                 unresolved = true;
             }
+            //TODO - if AttackingMove is Move via Convoy and AttackingMove is unresolved, then unresolved = true
         }
         if(!unresolved)
         {
@@ -50,7 +70,7 @@ public class MovementEvaluator(World world, List<Order> activeOrders, AdjacencyV
 
         int maxPreventStr = 0;
         int minPreventStr = 0;
-        foreach (var attackingMove in move.Destination.AttackingMoves)
+        foreach (Move attackingMove in move.Destination.AttackingMoves)
         {
             if (!Object.ReferenceEquals(attackingMove, move))
             {
@@ -82,7 +102,7 @@ public class MovementEvaluator(World world, List<Order> activeOrders, AdjacencyV
                     //So I'm thinking to maybe remove the MustRetreat line from here from here and calculate which units are dislodged after everything else is done.
                 }
 
-                foreach(var attackingMove in move.Destination.AttackingMoves)
+                foreach(Move attackingMove in move.Destination.AttackingMoves)
                 {
                     if(!Object.ReferenceEquals(attackingMove, move))
                     {

--- a/server/Adjudication/Evaluation/MovementEvaluator.cs
+++ b/server/Adjudication/Evaluation/MovementEvaluator.cs
@@ -22,5 +22,65 @@ public class MovementEvaluator(World world, List<Order> activeOrders, AdjacencyV
         // - Mark orders as success/failure
         // - Mark units needing retreat or add disbands if not possible (use adjacencyValidator)
     }
+
+    public void AdjudicateSupport(Support support)
+    {
+        foreach (var attackingMove in support.Location.AttackingMoves)
+        {
+            if (!Object.ReferenceEquals(support.Midpoint,support.Destination) && !Object.ReferenceEquals(support.Destination, attackingMove.Location))
+            {
+                //TODO - also need to check if it's an unresolved convoy move first...
+                support.Status = Enums.OrderStatus.Failure;
+            }
+        }
+
+    }
+
+    public void AdjudicateMove(Move move)
+    {
+
+        int maxPreventStr = 0;
+        int minPreventStr = 0;
+        foreach (var attackingMove in move.Destination.AttackingMoves)
+        {
+            if (!Object.ReferenceEquals(attackingMove, move))
+            {
+                if (attackingMove.PreventStrength.Max > maxPreventStr)
+                {
+                    maxPreventStr = attackingMove.PreventStrength.Max;
+                }
+                if (attackingMove.PreventStrength.Min > minPreventStr)
+                {
+                    minPreventStr = attackingMove.PreventStrength.Min;
+                }
+            }
+        }
+
+        if (((move.OpposingMove != null) && (move.AttackStrength.Min > move.OpposingMove.DefendStrength.Max)) || ((move.OpposingMove == null) && (move.AttackStrength.Min > move.Destination.HoldStrength.Max)))
+        {
+            if (move.AttackStrength.Min > maxPreventStr)
+            {
+                move.Status = Enums.OrderStatus.Success;
+                if(move.OpposingMove != null)
+                {
+                    move.OpposingMove.Unit.MustRetreat = true;
+                }
+                //Need to also check if the opposing territory has a unit present and dislodge it if true
+
+                foreach(var attackingMove in move.Destination.AttackingMoves)
+                {
+                    if(!Object.ReferenceEquals(attackingMove, move))
+                    {
+                        attackingMove.Status = Enums.OrderStatus.Failure;
+                    }
+                }
+            }
+        }
+
+        if (((move.OpposingMove != null) && (move.AttackStrength.Max <= move.OpposingMove.DefendStrength.Min)) || ((move.OpposingMove == null) && (move.AttackStrength.Max <= move.Destination.HoldStrength.Min)) || (move.AttackStrength.Max <= minPreventStr))
+        {
+            //unsuccessful
+        }
+    }
 }
 

--- a/server/Entities/Location.cs
+++ b/server/Entities/Location.cs
@@ -32,5 +32,5 @@ public class Location : IEquatable<Location>
     public OrderStrength HoldStrength { get; set; } = new();
 
     [NotMapped]
-    public Unit PresentUnit { get; set; }
+    public Order OrderAtLocation { get; set; }
 }

--- a/server/Entities/Location.cs
+++ b/server/Entities/Location.cs
@@ -24,4 +24,13 @@ public class Location : IEquatable<Location>
     public override bool Equals(object? obj) => Equals(obj as Location);
 
     public override int GetHashCode() => (Timeline, Year, Phase, RegionId).GetHashCode();
+
+    [NotMapped]
+    public List<Move> AttackingMoves { get; set; } = new List<Move>();
+
+    [NotMapped]
+    public OrderStrength HoldStrength { get; set; } = new();
+
+    [NotMapped]
+    public Unit PresentUnit { get; set; }
 }

--- a/server/Entities/Orders/Order.cs
+++ b/server/Entities/Orders/Order.cs
@@ -23,4 +23,7 @@ public abstract class Order
 
     [NotMapped]
     public OrderStrength HoldStrength { get; set; } = new();
+
+    [NotMapped]
+    public List<Support> PotentialSupports { get; set; } = [];
 }


### PR DESCRIPTION
Added some Adjudication methods, including Order Strength calculations and testing for success/failure of moves, supports and convoying fleets.

Still requires dependency logic, and move-via-convoys are not accounted for yet.