### PR TITLE
fix space causing format error

### DIFF
--- a/server/Tests/MDATC_B.cs
+++ b/server/Tests/MDATC_B.cs
@@ -412,7 +412,7 @@ public class MDATC_B : AdjudicationTestBase
                 (Nation.Germany, UnitType.Army, "Kie", false),
                 (Nation.Russia, UnitType.Army, "Mos", false),
                 (Nation.Russia, UnitType.Army, "Stp", false),
-                (Nation.Turkey, UnitType.Army, "Con",false),
+                (Nation.Turkey, UnitType.Army, "Con", false),
                 (Nation.Turkey, UnitType.Army, "Bul", false),
                 (Nation.Austria, UnitType.Army, "Vie", false),
                 (Nation.Austria, UnitType.Army, "Bud", false),


### PR DESCRIPTION
I'm not sure why, but my build wouldn't work unless this space was formatted properly.