### PR TITLE
Fix fleets supporting armies into regions with 2 coasts

### DIFF
--- a/server/Adjudication/Validation/AdjacencyValidator.cs
+++ b/server/Adjudication/Validation/AdjacencyValidator.cs
@@ -69,27 +69,25 @@ public class AdjacencyValidator(List<Region> regions, bool hasStrictAdjacencies)
 
         if (allowDestinationSibling)
         {
-            if (destinationRegion.ParentId != null)
+            var destinationRegionSiblings = regions.Where(r =>
+                r != destinationRegion
+                && (destinationRegion.ParentId != null || r.ParentId != null)
+                && (r.ParentId == destinationRegion.ParentId || r.ParentId == destinationRegion.Id || r.Id == destinationRegion.ParentId));
+
+            foreach (var siblingRegion in destinationRegionSiblings)
             {
-                var destinationRegionSiblings = regions.Where(r =>
-                    r != destinationRegion
-                    && r.ParentId == destinationRegion.ParentId);
-
-                foreach (var siblingRegion in destinationRegionSiblings)
+                var sibling = new Location
                 {
-                    var sibling = new Location
-                    {
-                        Timeline = destination.Timeline,
-                        Year = destination.Year,
-                        Phase = destination.Phase,
-                        RegionId = siblingRegion.Id,
-                    };
+                    Timeline = destination.Timeline,
+                    Year = destination.Year,
+                    Phase = destination.Phase,
+                    RegionId = siblingRegion.Id,
+                };
 
-                    var isValidMove = IsValidIntraBoardMove(unit, location, sibling, false, false);
-                    if (isValidMove)
-                    {
-                        return true;
-                    }
+                var isValidMove = IsValidIntraBoardMove(unit, location, sibling, false, false);
+                if (isValidMove)
+                {
+                    return true;
                 }
             }
         }


### PR DESCRIPTION
ValidateSupports is the only function which sets allowDestinationSibling, so this shouldn't affect anything except supports.

![image](https://github.com/user-attachments/assets/e4d24f57-fa6c-4713-a8c0-f7b1967fe47b)

An alternative way to fix this would be to consider all non-child regions to be their own parents. I didn't implement that because there are other uses of Region.ParentID that might be relying on the current behavior.
