### PR TITLE
Fix random launch bug

### DIFF
--- a/client/src/components/GameRoot.tsx
+++ b/client/src/components/GameRoot.tsx
@@ -26,7 +26,7 @@ const GameRoot = () => {
         initialPositionX={getDefaultOffsetX()}
         initialPositionY={getDefaultOffsetY()}
         doubleClick={{ disabled: true }}
-        panning={{ excluded: ['input', 'select'] }}
+        panning={{ excluded: ['input', 'select'], velocityDisabled: true }}
       >
         {error && <WorldError error={error} retry={retry} isLoading={isLoading} />}
         {!world && <WorldLoading />}


### PR DESCRIPTION
According to https://github.com/BetterTyped/react-zoom-pan-pinch/issues/408 this bug can be fixed by disabling velocity in panning settings. This has no effect at zoom < 1, but stops the momentum effect when zoomed further than that.

Fixes #11