### PR TITLE
Quick and dirty background worker

### DIFF
--- a/server/Program.cs
+++ b/server/Program.cs
@@ -10,6 +10,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers().AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddResponseCompression();
 builder.Services.AddDbContext<GameContext>(options => options.UseSqlServer(builder.Configuration.GetConnectionString("Database")));
 
 builder.Services.AddScoped<EntityMapper>();
@@ -19,8 +20,12 @@ builder.Services.AddScoped<WorldRepository>();
 builder.Services.AddScoped<MapFactory>();
 builder.Services.AddScoped<DefaultWorldFactory>();
 
+builder.Services.AddSingleton<Services.BackgroundTaskQueue>();
+builder.Services.AddHostedService<Services.BackgroundQueueHostedService>();
+
 var app = builder.Build();
 
+app.UseResponseCompression(); //Compression early in the middleware, to compress everything by default
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();

--- a/server/Services/BackgroundTaskHost.cs
+++ b/server/Services/BackgroundTaskHost.cs
@@ -1,0 +1,30 @@
+
+namespace Services;
+
+public class BackgroundQueueHostedService(BackgroundTaskQueue taskQueue, IServiceScopeFactory serviceScopeFactory, ILogger<BackgroundQueueHostedService> logger) : BackgroundService
+{
+    private readonly BackgroundTaskQueue _taskQueue = taskQueue ?? throw new ArgumentNullException(nameof(taskQueue));
+    private readonly IServiceScopeFactory _serviceScopeFactory = serviceScopeFactory ?? throw new ArgumentNullException(nameof(serviceScopeFactory));
+    private readonly ILogger<BackgroundQueueHostedService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Dequeue and execute tasks until the application is stopped
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Get next task
+            // This blocks until a task becomes available
+            var task = await _taskQueue.DequeueAsync(stoppingToken);
+
+            try
+            {
+                // Run the task into the background threadpool. NOTE: this is not really a good idea to throw thousands of tiny at, nor more than one-per-core-ish for compute heavy.
+                _ = Task.Run(async () => await task(_serviceScopeFactory, stoppingToken));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occured during execution of a background task");
+            }
+        }
+    }
+}

--- a/server/Services/BackgroundTaskQueue.cs
+++ b/server/Services/BackgroundTaskQueue.cs
@@ -1,0 +1,38 @@
+
+using System.Collections.Concurrent;
+
+namespace Services;
+
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public class BackgroundTaskQueue
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable
+
+{
+    private readonly ConcurrentQueue<Func<IServiceScopeFactory, CancellationToken, Task>> _items = new();
+
+    // Holds the current count of tasks in the queue.
+    private readonly SemaphoreSlim _signal = new(0);
+
+    public void EnqueueTask(Func<IServiceScopeFactory, CancellationToken, Task> task)
+    {
+        if (task == null)
+        {
+            throw new ArgumentNullException(nameof(task));
+        }
+
+        _items.Enqueue(task);
+        _signal.Release();
+    }
+
+    public async Task<Func<IServiceScopeFactory, CancellationToken, Task>> DequeueAsync(CancellationToken cancellationToken)
+    {
+        // Wait for task to become available
+        await _signal.WaitAsync(cancellationToken);
+
+        return _items.TryDequeue(out var task)
+            ? task
+            : throw new Exception("For some reason, somehow, workqueue became desynced from its semaphore lock");
+    }
+}


### PR DESCRIPTION
Quick and dirty background worker and response compression to improve end-of-turn performance by hiding it under the rug for the moment.

Basically per quick analysis:

1. last player submits orders
2. This triggers the Adjudication calculations/etc, but this happened on the HTTP Request thread/stack
3. This would/could block other requests from processing, (note: there *are* more than just one HTTP Request thread though) if such occurred a player would receive many events at once and the UI would probably be sad :( and have to first (on each client) "catch up" or re-re-re-re-draw the current new state, whichever won the request vs database races.
4. These JSON responses get big *fast*, lets enable server-side compression by default and see how much this helps