### PR TITLE
Websockets instead of polling

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "react": "^18.2.0",
     "react-activity": "^2.1.3",
     "react-dom": "^18.2.0",
+    "react-use-websocket": "^4.13.0",
     "react-zoom-pan-pinch": "^3.4.4",
     "tailwindcss": "^3.4.4",
     "vite": "^5.2.2",

--- a/client/src/api/routes.ts
+++ b/client/src/api/routes.ts
@@ -5,6 +5,7 @@ const routes = {
   joinGame: (gameId: number) => `${baseUrl}/game/${gameId}/players`,
   getWorld: (gameId: number) => `${baseUrl}/game/${gameId}`,
   submitOrders: (gameId: number) => `${baseUrl}/game/${gameId}/orders`,
+  getWorldWebSocket: (gameId: number) => `${baseUrl}/game/${gameId}/ws`,
 };
 
 export default routes;

--- a/client/src/components/context/WorldContext.tsx
+++ b/client/src/components/context/WorldContext.tsx
@@ -1,12 +1,11 @@
 import { createContext, PropsWithChildren, useContext, useMemo, useState } from 'react';
-import useWebSocket from 'react-use-websocket';
 import World from '../../types/world';
 import Order, { OrderStatus } from '../../types/order';
 import useGetWorld from '../../hooks/api/useGetWorld';
 import useSubmitOrders from '../../hooks/api/useSubmitOrders';
 import GameContext from './GameContext';
 import Nation from '../../types/enums/nation';
-import routes from '../../api/routes';
+import useGetWorldWebSockets from '../../hooks/api/useGetWorldWebSockets';
 
 type WorldContextState = {
   world: World | null;
@@ -30,18 +29,10 @@ export const WorldContextProvider = ({ children }: PropsWithChildren) => {
   const { game } = useContext(GameContext);
 
   const { world, isLoading, error: worldError, refetch } = useGetWorld();
+  const { lastMessage } = useGetWorldWebSockets();
   const { submitOrders, isPending: isSubmitting, error: submissionError } = useSubmitOrders();
 
   const [isWaitingForUpdate, setIsWaitingForUpdate] = useState(false);
-
-  const { lastMessage } = useWebSocket(game ? routes.getWorldWebSocket(game.id) : '', {
-    retryOnError: true,
-    reconnectAttempts: 10,
-    reconnectInterval: (attemptNumber) => Math.min(2 ** attemptNumber * 1000, 10000),
-    queryParams: {
-      player: `${game?.player}`,
-    },
-  });
 
   const websocketWorld = useMemo(() => {
     setIsWaitingForUpdate(false);

--- a/client/src/components/context/WorldContext.tsx
+++ b/client/src/components/context/WorldContext.tsx
@@ -1,18 +1,12 @@
-import {
-  createContext,
-  PropsWithChildren,
-  useCallback,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
+import { createContext, PropsWithChildren, useContext, useMemo, useState } from 'react';
+import useWebSocket from 'react-use-websocket';
 import World from '../../types/world';
 import Order, { OrderStatus } from '../../types/order';
 import useGetWorld from '../../hooks/api/useGetWorld';
 import useSubmitOrders from '../../hooks/api/useSubmitOrders';
-import { refetchInterval } from '../../utils/constants';
 import GameContext from './GameContext';
 import Nation from '../../types/enums/nation';
+import routes from '../../api/routes';
 
 type WorldContextState = {
   world: World | null;
@@ -38,51 +32,54 @@ export const WorldContextProvider = ({ children }: PropsWithChildren) => {
   const { world, isLoading, error: worldError, refetch } = useGetWorld();
   const { submitOrders, isPending: isSubmitting, error: submissionError } = useSubmitOrders();
 
-  const [isRefetching, setIsRefetching] = useState(false);
+  const [isWaitingForUpdate, setIsWaitingForUpdate] = useState(false);
+
+  const { lastMessage } = useWebSocket(game ? routes.getWorldWebSocket(game.id) : '', {
+    retryOnError: true,
+    reconnectAttempts: 10,
+    reconnectInterval: (attemptNumber) => Math.min(2 ** attemptNumber * 1000, 10000),
+    queryParams: {
+      player: `${game?.player}`,
+    },
+  });
+
+  const websocketWorld = useMemo(() => {
+    setIsWaitingForUpdate(false);
+    return lastMessage ? (JSON.parse(lastMessage.data) as World) : null;
+  }, [lastMessage]);
+
+  const latestWorld =
+    websocketWorld && (!world || websocketWorld.iteration > world.iteration)
+      ? websocketWorld
+      : world;
 
   const isWaitingForAdjudication =
-    world?.orders.some((order) => order.status === OrderStatus.New) ?? false;
-
-  const refetchUntilUpdate = useCallback(async () => {
-    setIsRefetching(true);
-    const currentIteration = world?.iteration;
-    const refetched = await refetch();
-    if (refetched.error || currentIteration !== refetched.data?.iteration) {
-      setIsRefetching(false);
-      return refetched;
-    }
-
-    await new Promise((resolve) => {
-      setTimeout(resolve, refetchInterval);
-    });
-
-    return refetchUntilUpdate();
-  }, [world?.iteration, refetch]);
+    latestWorld?.orders.some((order) => order.status === OrderStatus.New) ?? false;
 
   const contextValue = useMemo(
     () => ({
-      world,
+      world: latestWorld,
       submitOrders: async (orders: Order[]) => {
-        if (!game || !world) return;
+        if (!game || !latestWorld) return;
         const players = game.player ? [game.player] : Object.values(Nation);
+        setIsWaitingForUpdate(true);
         await submitOrders({ gameId: game.id, players, orders });
-        await refetchUntilUpdate();
       },
-      isLoading: isLoading || isSubmitting || isRefetching || isWaitingForAdjudication,
+      isLoading: isLoading || isSubmitting || isWaitingForAdjudication || isWaitingForUpdate,
       error: worldError || submissionError,
-      retry: () => refetchUntilUpdate(),
+      retry: () => refetch(),
     }),
     [
       game,
-      world,
+      latestWorld,
       submitOrders,
       isLoading,
       isSubmitting,
-      isRefetching,
       isWaitingForAdjudication,
+      isWaitingForUpdate,
       worldError,
       submissionError,
-      refetchUntilUpdate,
+      refetch,
     ],
   );
 

--- a/client/src/hooks/api/useGetWorldWebSockets.tsx
+++ b/client/src/hooks/api/useGetWorldWebSockets.tsx
@@ -1,0 +1,24 @@
+import { useContext } from 'react';
+import useWebSocket from 'react-use-websocket';
+import { QueryParams } from 'react-use-websocket/dist/lib/types';
+import GameContext from '../../components/context/GameContext';
+import routes from '../../api/routes';
+
+const useGetWorldWebSockets = () => {
+  const { game } = useContext(GameContext);
+
+  const queryParams: QueryParams | undefined = game?.player
+    ? { player: `${game.player}` }
+    : undefined;
+
+  const { lastMessage } = useWebSocket(game ? routes.getWorldWebSocket(game.id) : '', {
+    retryOnError: true,
+    reconnectAttempts: 10,
+    reconnectInterval: (attemptNumber) => Math.min(2 ** attemptNumber * 1000, 10000),
+    queryParams,
+  });
+
+  return { lastMessage };
+};
+
+export default useGetWorldWebSockets;

--- a/server/Adjudication/Adjudicator.cs
+++ b/server/Adjudication/Adjudicator.cs
@@ -13,6 +13,9 @@ public class Adjudicator
     private readonly Evaluator evaluator;
     private readonly Executor executor;
 
+    public delegate void AdjudicationEvent(World world);
+    public static event AdjudicationEvent? Adjudicated;
+
     public Adjudicator(World world, bool hasStrictAdjacencies, MapFactory mapFactory, DefaultWorldFactory defaultWorldFactory)
     {
         this.world = world;
@@ -43,6 +46,8 @@ public class Adjudicator
         {
             world.Winner = winner;
         }
+
+        Adjudicated?.Invoke(world);
     }
 
     private Nation? GetWinner()

--- a/server/Controllers/GameController.cs
+++ b/server/Controllers/GameController.cs
@@ -13,7 +13,8 @@ public class GameController(
     EntityMapper entityMapper,
     ModelMapper modelMapper,
     GameRepository gameRepository,
-    WorldRepository worldRepository) : ControllerBase
+    WorldRepository worldRepository,
+    WebSocketConnectionManager webSocketConnectionManager) : ControllerBase
 {
     private readonly ILogger<GameController> logger = logger;
     private readonly EntityMapper entityMapper = entityMapper;
@@ -93,6 +94,27 @@ public class GameController(
         {
             logger.LogWarning("Failed to find world with ID {GameId}", gameId);
             return NotFound($"No world with game ID {gameId} found");
+        }
+    }
+
+    [HttpGet]
+    [Route("{gameId}/ws")]
+    public async Task GetWorldWebSockets([FromRoute] int gameId, [FromQuery] Nation player)
+    {
+        if (HttpContext.WebSockets.IsWebSocketRequest)
+        {
+            logger.LogInformation("WebSocket GetWorld connection request for game {GameId} as {Player}", gameId, player);
+
+            using var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync();
+            var socketFinishedTcs = new TaskCompletionSource<object>();
+
+            webSocketConnectionManager.AddConnection(webSocket, socketFinishedTcs, gameId, player);
+
+            await socketFinishedTcs.Task;
+        }
+        else
+        {
+            HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
         }
     }
 

--- a/server/Controllers/WebSocketConnectionManager.cs
+++ b/server/Controllers/WebSocketConnectionManager.cs
@@ -1,0 +1,99 @@
+using System.Net.WebSockets;
+using Adjudication;
+using Enums;
+using Entities;
+using System.Text.Json;
+using Mappers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Controllers;
+
+public class WebSocketConnectionManager
+{
+    private readonly List<Connection> connections = [];
+    private readonly EntityMapper entityMapper = new();
+    private readonly ILogger<WebSocketConnectionManager> logger;
+
+    private readonly JsonSerializerOptions jsonSerializerOptions;
+
+    public WebSocketConnectionManager(ILogger<WebSocketConnectionManager> logger, IOptions<JsonOptions> jsonOptions)
+    {
+        this.logger = logger;
+        Adjudicator.Adjudicated += SendUpdatedWorldData;
+
+        jsonSerializerOptions = jsonOptions.Value.JsonSerializerOptions;
+    }
+
+    public void AddConnection(WebSocket socket, TaskCompletionSource<object> socketFinishedTcs, int gameId, Nation player)
+    {
+        lock (connections)
+        {
+            var connection = new Connection(socket, socketFinishedTcs, gameId, player);
+            connections.Add(connection);
+            ListenForClose(connection);
+        }
+    }
+
+    private void SendUpdatedWorldData(World world)
+    {
+        lock (connections)
+        {
+            logger.LogInformation("Sending world update for game {GameId} to websocket listeners", world.GameId);
+            foreach (var connection in connections)
+            {
+                if (connection.Socket.CloseStatus != null)
+                {
+                    CleanupConnection(connection);
+                    continue;
+                }
+
+                if (connection.GameId == world.GameId)
+                {
+                    var data = JsonSerializer.SerializeToUtf8Bytes(entityMapper.MapWorld(world, connection.Player), jsonSerializerOptions);
+                    try
+                    {
+                        connection.Socket.SendAsync(data, WebSocketMessageType.Text, true, CancellationToken.None);
+                    }
+                    catch (WebSocketException ex)
+                    {
+                        logger.LogError("Exception when sending world update for game {GameId} to player {Player}: {Exception}", world.GameId, connection.Player, ex);
+                    }
+                }
+            }
+        }
+    }
+
+    private async void ListenForClose(Connection connection)
+    {
+        try
+        {
+            byte[] buff = [];
+            await connection.Socket.ReceiveAsync(buff, CancellationToken.None);
+        }
+        catch (WebSocketException) { }
+        finally
+        {
+            lock (connections)
+            {
+                CleanupConnection(connection);
+            }
+        }
+    }
+
+    private void CleanupConnection(Connection connection)
+    {
+        logger.LogInformation("Removing connection for player {Player} in game {GameId}", connection.Player, connection.GameId);
+        connections.Remove(connection);
+        connection.Socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
+        connection.SocketFinishedTcs.SetResult("");
+    }
+
+    private readonly struct Connection(WebSocket socket, TaskCompletionSource<object> socketFinishedTcs, int gameId, Nation player)
+    {
+        public readonly WebSocket Socket = socket;
+        public readonly TaskCompletionSource<object> SocketFinishedTcs = socketFinishedTcs;
+        public readonly int GameId = gameId;
+        public readonly Nation Player = player;
+    }
+}

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -1,4 +1,5 @@
 using Context;
+using Controllers;
 using Factories;
 using Mappers;
 using Microsoft.EntityFrameworkCore;
@@ -11,6 +12,8 @@ builder.Services.AddControllers().AddJsonOptions(options => options.JsonSerializ
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddDbContext<GameContext>(options => options.UseSqlServer(builder.Configuration.GetConnectionString("Database")));
+
+builder.Services.AddSingleton<WebSocketConnectionManager>();
 
 builder.Services.AddScoped<EntityMapper>();
 builder.Services.AddScoped<ModelMapper>();
@@ -32,5 +35,9 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseAuthorization();
+app.UseWebSockets(new WebSocketOptions
+{
+    KeepAliveInterval = TimeSpan.FromSeconds(30)
+});
 app.MapControllers();
 app.Run();

--- a/server/Repositories/WorldRepository.cs
+++ b/server/Repositories/WorldRepository.cs
@@ -47,9 +47,9 @@ public class WorldRepository(ILogger<WorldRepository> logger, GameContext contex
 
             game.PlayersSubmitted = [];
 
+            world.Iteration++;
             var adjudicator = new Adjudicator(world, game.HasStrictAdjacencies, mapFactory, defaultWorldFactory);
             adjudicator.Adjudicate();
-            world.Iteration++;
 
             logger.LogInformation("Adjudicated game {GameId}", gameId);
         }


### PR DESCRIPTION
Use WebSockets to fetch the game state instead of actively polling for changes. The server sends an update to all listeners whenever adjudication is finished.
Benefits:
- Reduced network traffic and load on backend (data is only sent when an update occurs)
- Reduced load on the database (when adjudication finishes an event is sent out that contains the world state, that state is then sent to every client without additional database querries)

I had started work on this before the merge of the iteration fix, so this is a bit redundant since that already fixes most of the problem, but I feel like this is a bit of an upgrade on top of that.

Tl;dr on how it works: added new endpoint to the backend `GET game/{gameId}/ws` that receives a WebSocket connection and registers it at the `WebSocketConnectionManager`. Whenever the `Adjudicate()` method finishes, an event is invoked that runs `WebSocketConnectionManager.SendUpdatedWorldData(World world)` which goes through all active WebSocket connections and sends the updated world data.

On the frontend side, what was previously isRefetching is now replaced with isWaitingForUpdate which is set to true when submit is clicked and to false when the websocket gets a reply.