### PR TITLE
Add map rasterization to improve client responsiveness when zoomed out.

### DIFF
--- a/client/src/assets/map/Yor.svg
+++ b/client/src/assets/map/Yor.svg
@@ -6,7 +6,7 @@
 	</defs>
  <g id="Document" fill="none" stroke="black" font-family="Times New Roman" font-size="16" transform="scale(1 -1)">
   <g id="Spread" transform="translate(0 -1077.17)">
-   <g id="Layer 1" pointer-events="auto" pointer-events="auto">
+   <g id="Layer 1" pointer-events="auto">
     <g id="Group" stroke-linejoin="round" stroke-width="1.73" fill="currentColor" fill-rule="evenodd" stroke="#ffffff">
      <path d="M 288.306,633.193 L 288.306,610.204 L 297.146,597.818 L 300.687,587.208 L 298.917,564.214 L 293.611,557.139 L 270.615,553.603 L 265.31,565.984 L 267.08,594.283 L 274.155,610.204 L 274.155,629.66 Z" marker-start="none" marker-end="none"/>
     </g>

--- a/client/src/components/GameRoot.tsx
+++ b/client/src/components/GameRoot.tsx
@@ -11,6 +11,7 @@ import BoardArrowLayer from './world/arrows/BoardArrowLayer';
 import WorldContext from './context/WorldContext';
 import { getDefaultOffsetX, getDefaultOffsetY } from '../utils/navigationUtils';
 import BackgroundLayer from './world/BackgroundLayer';
+import { ScaleContextProvider } from './context/ScaleContext';
 
 const GameRoot = () => {
   const { world, isLoading, error, retry } = useContext(WorldContext);
@@ -29,17 +30,19 @@ const GameRoot = () => {
         doubleClick={{ disabled: true }}
         panning={{ excluded: ['input', 'select'], velocityDisabled: true }}
       >
-        {error && <WorldError error={error} retry={retry} isLoading={isLoading} />}
-        {!world && <WorldLoading />}
-        {!error && (
-          <TransformComponent>
-            <BackgroundLayer />
-            <BoardArrowLayer />
-            <BoardLayer />
-            <OrderLayer />
-          </TransformComponent>
-        )}
-        <Overlay />
+        <ScaleContextProvider>
+          {error && <WorldError error={error} retry={retry} isLoading={isLoading} />}
+          {!world && <WorldLoading />}
+          {!error && (
+            <TransformComponent>
+              <BackgroundLayer />
+              <BoardArrowLayer />
+              <BoardLayer />
+              <OrderLayer />
+            </TransformComponent>
+          )}
+          <Overlay />
+        </ScaleContextProvider>
       </TransformWrapper>
     </OrderEntryContextProvider>
   );

--- a/client/src/components/context/ScaleContext.tsx
+++ b/client/src/components/context/ScaleContext.tsx
@@ -1,0 +1,58 @@
+import { createContext, PropsWithChildren, useEffect, useMemo, useState } from 'react';
+import { useTransformContext } from 'react-zoom-pan-pinch';
+import { initialScale } from '../../utils/constants';
+import { getDefaultOffsetX, getDefaultOffsetY } from '../../utils/navigationUtils';
+
+type ScaleContextState = {
+  scale: number;
+  positionX: number;
+  positionY: number;
+};
+
+const initialScaleContextState: ScaleContextState = {
+  scale: initialScale,
+  positionX: getDefaultOffsetX(),
+  positionY: getDefaultOffsetY(),
+};
+
+const ScaleContext = createContext(initialScaleContextState);
+
+export const ScaleContextProvider = ({ children }: PropsWithChildren) => {
+  const { onChangeCallbacks } = useTransformContext();
+
+  const [scale, setScale] = useState(initialScale);
+  const [positionX, setPositionX] = useState(getDefaultOffsetX());
+  const [positionY, setPositionY] = useState(getDefaultOffsetY());
+
+  useEffect(() => {
+    const callback = ({
+      state,
+    }: {
+      state: { scale: number; positionX: number; positionY: number };
+    }) => {
+      if (scale !== state.scale || positionX !== state.positionX || positionY !== state.positionY) {
+        setScale(state.scale);
+        setPositionX(state.positionX);
+        setPositionY(state.positionY);
+      }
+    };
+
+    onChangeCallbacks.add(callback);
+    return () => {
+      onChangeCallbacks.delete(callback);
+    };
+  }, [onChangeCallbacks, scale, positionX, positionY]);
+
+  const contextValue: ScaleContextState = useMemo(
+    () => ({
+      scale,
+      positionX,
+      positionY,
+    }),
+    [scale, positionX, positionY],
+  );
+
+  return <ScaleContext.Provider value={contextValue}>{children}</ScaleContext.Provider>;
+};
+
+export default ScaleContext;

--- a/client/src/components/context/WorkQueueContext.tsx
+++ b/client/src/components/context/WorkQueueContext.tsx
@@ -1,0 +1,41 @@
+import { createContext } from 'react';
+
+const noopQueue: WorkQueue = { push: () => {}, sharedCache: new Map() };
+const WorkQueueContext = createContext<WorkQueue>(noopQueue);
+
+export const createWorkQueue = (): WorkQueue => {
+  const queue: { work: () => void; rank: () => number }[] = [];
+  const executeNextWorkItem = () => {
+    const nextWorkItem = queue
+      .map((item, index) => ({ work: item.work, rank: item.rank(), index }))
+      .reduce((previous, current) => (current.rank < previous.rank ? current : previous));
+    queue.splice(nextWorkItem.index, 1);
+    nextWorkItem.work();
+  };
+  return {
+    push: (workItem: (onComplete: () => void) => void, rank: () => number) => {
+      queue.push({
+        work: () => {
+          workItem(() => {
+            if (queue.length > 0) {
+              setTimeout(executeNextWorkItem, 1);
+            }
+          });
+        },
+        rank,
+      });
+
+      if (queue.length === 1) {
+        setTimeout(executeNextWorkItem, 1);
+      }
+    },
+    sharedCache: new Map(),
+  };
+};
+
+export type WorkQueue = {
+  push: (workItem: (onComplete: () => void) => void, rank: () => number) => void;
+  sharedCache: Map<unknown, unknown>;
+};
+
+export default WorkQueueContext;

--- a/client/src/components/user-interface/CoordinateDisplay.tsx
+++ b/client/src/components/user-interface/CoordinateDisplay.tsx
@@ -1,33 +1,12 @@
 import { useTransformContext } from 'react-zoom-pan-pinch';
-import { useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { initialScale } from '../../utils/constants';
 import { getDefaultOffsetX, getDefaultOffsetY } from '../../utils/navigationUtils';
+import ScaleContext from '../context/ScaleContext';
 
 const CoordinateDisplay = () => {
-  const { setTransformState, onChangeCallbacks } = useTransformContext();
-
-  const [scale, setScale] = useState(initialScale);
-  const [positionX, setPositionX] = useState(getDefaultOffsetX());
-  const [positionY, setPositionY] = useState(getDefaultOffsetY());
-
-  useEffect(() => {
-    const callback = ({
-      state,
-    }: {
-      state: { scale: number; positionX: number; positionY: number };
-    }) => {
-      if (scale !== state.scale || positionX !== state.positionX || positionY !== state.positionY) {
-        setScale(state.scale);
-        setPositionX(state.positionX);
-        setPositionY(state.positionY);
-      }
-    };
-
-    onChangeCallbacks.add(callback);
-    return () => {
-      onChangeCallbacks.delete(callback);
-    };
-  }, [onChangeCallbacks, scale, positionX, positionY]);
+  const { setTransformState } = useTransformContext();
+  const { scale, positionX, positionY } = useContext(ScaleContext);
 
   const coordinateText = `${scale} (${positionX}, ${positionY})`;
 

--- a/client/src/components/user-interface/InputModeButtonList.tsx
+++ b/client/src/components/user-interface/InputModeButtonList.tsx
@@ -1,19 +1,34 @@
+import { useContext, useMemo } from 'react';
 import useSetAvailableInputModes from '../../hooks/useSetAvailableInputModes';
 import InputMode from '../../types/enums/inputMode';
 import InputModeButton from './InputModeButton';
+import { rasteriseEnabled, rasteriseScaleThreshold } from '../../utils/constants';
+import ScaleContext from '../context/ScaleContext';
 
 const InputModeButtonList = () => {
   useSetAvailableInputModes();
 
-  const inputButtons = Object.values(InputMode)
-    .filter((mode) => mode !== InputMode.None)
-    .map((mode) => <InputModeButton mode={mode} key={mode} />);
+  const { scale } = useContext(ScaleContext);
 
-  return (
-    <div className="absolute bottom-10 w-screen flex gap-10 justify-center pointer-events-none">
-      {inputButtons}
-    </div>
-  );
+  const showRasterised = rasteriseEnabled && scale < rasteriseScaleThreshold;
+
+  const buttons = useMemo(() => {
+    if (showRasterised) {
+      return null;
+    }
+
+    const inputButtons = Object.values(InputMode)
+      .filter((mode) => mode !== InputMode.None)
+      .map((mode) => <InputModeButton mode={mode} key={mode} />);
+
+    return (
+      <div className="absolute bottom-10 w-screen flex gap-10 justify-center pointer-events-none">
+        {inputButtons}
+      </div>
+    );
+  }, [showRasterised]);
+
+  return buttons;
 };
 
 export default InputModeButtonList;

--- a/client/src/components/world/boards/Board.tsx
+++ b/client/src/components/world/boards/Board.tsx
@@ -39,7 +39,6 @@ const Board = ({ board, winner, isActive }: BoardProps) => {
       }}
     >
       <div className="rounded-xl" style={{ backgroundColor: colours.boardBackground }}>
-        <p className="text-md absolute left-8 top-1 z-10">{getBoardName(board)}</p>
         <div
           className="relative rounded-xl"
           style={{
@@ -53,6 +52,7 @@ const Board = ({ board, winner, isActive }: BoardProps) => {
             boxShadow: winner && isActive ? `0px 0px 100px 50px ${getNationColour(winner)}` : '',
           }}
         >
+          <p className="text-md absolute z-10 -mt-7">{getBoardName(board)}</p>
           <Map board={board} />
           {!canMove && (
             <div

--- a/client/src/components/world/boards/BoardLayer.tsx
+++ b/client/src/components/world/boards/BoardLayer.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import { getNextMajorPhase, getPhaseIndex } from '../../../types/enums/phase';
 import { filterUnique } from '../../../utils/listUtils';
 import Board from './Board';
@@ -7,10 +7,16 @@ import WorldContext from '../../context/WorldContext';
 import BoardGhost from './BoardGhost';
 import OrderEntryContext from '../../context/OrderEntryContext';
 import InputMode from '../../../types/enums/inputMode';
+import WorkQueueContext, { createWorkQueue, WorkQueue } from '../../context/WorkQueueContext';
 
 const BoardLayer = () => {
   const { world } = useContext(WorldContext);
   const { currentMode, currentOrder } = useContext(OrderEntryContext);
+
+  // Rasterisation shares a queue, this allows one item to be resolved at a time and displayed incrementally for better UX.
+  // Without the queue, we'd try and rasterise everything at once which chugs the browser for a while.
+  const rasteriseQueue = useMemo<WorkQueue>(createWorkQueue, []);
+
   if (!world) return null;
 
   const timelines = filterUnique(world.boards.map(({ timeline }) => timeline));
@@ -31,36 +37,38 @@ const BoardLayer = () => {
 
   return (
     <div className="flex flex-col w-screen h-screen ">
-      {timelines.map((timeline) => (
-        <div className="flex" key={timeline}>
-          {boards.map((board) => {
-            const { year, phase } = board;
-            const possibleBoard = world.boards.find(
-              (worldBoard) =>
-                worldBoard.timeline === timeline &&
-                worldBoard.year === year &&
-                worldBoard.phase === phase,
-            );
+      <WorkQueueContext.Provider value={rasteriseQueue}>
+        {timelines.map((timeline) => (
+          <div className="flex" key={timeline}>
+            {boards.map((board) => {
+              const { year, phase } = board;
+              const possibleBoard = world.boards.find(
+                (worldBoard) =>
+                  worldBoard.timeline === timeline &&
+                  worldBoard.year === year &&
+                  worldBoard.phase === phase,
+              );
 
-            const key = `${board.year}-${board.phase}`;
+              const key = `${board.year}-${board.phase}`;
 
-            if (!possibleBoard) return <BoardSkip key={key} board={{ ...board, timeline }} />;
+              if (!possibleBoard) return <BoardSkip key={key} board={{ ...board, timeline }} />;
 
-            const hasNextBoard = world.boards.some(
-              (worldBoard) =>
-                worldBoard.timeline === timeline &&
-                (worldBoard.year > board.year ||
-                  (worldBoard.year === board.year &&
-                    getPhaseIndex(worldBoard.phase) > getPhaseIndex(board.phase))),
-            );
+              const hasNextBoard = world.boards.some(
+                (worldBoard) =>
+                  worldBoard.timeline === timeline &&
+                  (worldBoard.year > board.year ||
+                    (worldBoard.year === board.year &&
+                      getPhaseIndex(worldBoard.phase) > getPhaseIndex(board.phase))),
+              );
 
-            return (
-              <Board key={key} board={possibleBoard} winner={winner} isActive={!hasNextBoard} />
-            );
-          })}
-          {timeline === selectedLocation?.timeline && ghostBoard}
-        </div>
-      ))}
+              return (
+                <Board key={key} board={possibleBoard} winner={winner} isActive={!hasNextBoard} />
+              );
+            })}
+            {timeline === selectedLocation?.timeline && ghostBoard}
+          </div>
+        ))}
+      </WorkQueueContext.Provider>
     </div>
   );
 };

--- a/client/src/components/world/boards/Region.tsx
+++ b/client/src/components/world/boards/Region.tsx
@@ -3,11 +3,11 @@ import Nation, { getNationColour } from '../../../types/enums/nation';
 import OrderEntryContext from '../../context/OrderEntryContext';
 import { OrderEntryActionType } from '../../../types/context/orderEntryAction';
 import Unit from '../../../types/unit';
-import useRegionSvg from '../../../hooks/useRegionSvg';
+import { useRegionSvg, getRegionSvgRaw } from '../../../hooks/useRegionSvg';
 import regions from '../../../data/regions';
 import Phase from '../../../types/enums/phase';
 import { boardBorderWidth, majorBoardWidth, minorBoardWidth } from '../../../utils/constants';
-import UnitIcon from './UnitIcon';
+import UnitIcon, { rasteriseUnitIcon } from './UnitIcon';
 import { compareLocations, getLocationKey } from '../../../types/location';
 import { OrderType } from '../../../types/order';
 import BuildOptions from '../../user-interface/BuildOption';
@@ -26,7 +26,7 @@ const getRegionColour = (
   return getNationColour(owner, isHovering);
 };
 
-type RegionProps = {
+export type RegionProps = {
   id: string;
   timeline: number;
   year: number;
@@ -34,6 +34,94 @@ type RegionProps = {
   owner?: Nation;
   unit?: Unit;
   isVisible?: boolean;
+};
+
+export const rasteriseRegion = (
+  imageCache: Map<string, Promise<CanvasImageSource>>,
+  { id, owner, unit, phase }: RegionProps,
+  canvas: HTMLCanvasElement,
+  context: CanvasRenderingContext2D,
+  onComplete: () => void,
+) => {
+  const files = getRegionSvgRaw(id)!;
+
+  let filesLeft = files.length;
+  Object.values(files).forEach((file, index) => {
+    const drawImage = (image: CanvasImageSource) => {
+      context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+      // Draw unit icons once region(s) are drawn.
+      filesLeft--;
+      if (filesLeft === 0) {
+        if (unit) {
+          const { x, y } = regions[id];
+          const scaleFactor =
+            phase === Phase.Winter
+              ? (minorBoardWidth - boardBorderWidth * 2) / (majorBoardWidth - boardBorderWidth * 2)
+              : 1;
+          rasteriseUnitIcon(
+            imageCache,
+            { unit, scaleFactor },
+            x * scaleFactor,
+            y * scaleFactor,
+            canvas,
+            context,
+            onComplete,
+          );
+        } else {
+          onComplete();
+        }
+      }
+    };
+
+    // When drawing to canvas, CSS won't be applied, we'll need to apply the same effects manually.
+    const computedStyle = window.getComputedStyle(canvas);
+
+    let regionColour = getRegionColour(false, false, owner, regions[id].type === RegionType.Sea);
+    regionColour = regionColour.replace('var(', '').replace(')', '');
+    regionColour = computedStyle.getPropertyValue(regionColour);
+
+    const cacheKey = `region|${id}|${index}|${regionColour}`;
+    const cachedImage = imageCache.get(cacheKey);
+    if (cachedImage !== undefined) {
+      cachedImage.then(drawImage);
+    } else {
+      let svg = file;
+
+      // Apply the SVG colour attribute.
+      svg = svg.replace('"currentColor"', `"${regionColour}"`);
+
+      // Apply CSS rules for regions from index.css.
+      const boardCountryBorder = computedStyle.getPropertyValue('--board-country-border');
+      const sea = computedStyle.getPropertyValue('--sea');
+      const supplyCenter = computedStyle.getPropertyValue('--supply-center');
+      const supplyCenterBorder = computedStyle.getPropertyValue('--supply-center-border');
+      const svgDoc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+      svgDoc.querySelectorAll('path.sea-region').forEach((e) => e.setAttribute('fill', sea));
+      svgDoc.querySelectorAll('path').forEach((e) => e.setAttribute('stroke', boardCountryBorder));
+      svgDoc
+        .querySelectorAll('g.supply-center-dot')
+        .forEach((e) => e.setAttribute('fill', supplyCenter));
+      svgDoc
+        .querySelectorAll('g.supply-center-dot path')
+        .forEach((e) => e.setAttribute('stroke', supplyCenterBorder));
+      svg = new XMLSerializer().serializeToString(svgDoc);
+
+      // Create a URL we can load as the image source.
+      const blob = new Blob([svg], { type: 'image/svg+xml' });
+      const url = URL.createObjectURL(blob);
+      const image = new Image();
+      image.src = url;
+      const promise = new Promise<CanvasImageSource>((resolve) => {
+        image.onload = async () => {
+          URL.revokeObjectURL(url);
+          resolve(image);
+          drawImage(image);
+        };
+      });
+      imageCache.set(cacheKey, promise);
+    }
+  });
 };
 
 const Region = ({ id, timeline, year, phase, owner, unit, isVisible = true }: RegionProps) => {

--- a/client/src/components/world/boards/UnitIcon.tsx
+++ b/client/src/components/world/boards/UnitIcon.tsx
@@ -1,14 +1,82 @@
 import { getNationColour } from '../../../types/enums/nation';
 import Unit from '../../../types/unit';
 import UnitType from '../../../types/enums/unitType';
-import { unitWidth } from '../../../utils/constants';
+import { rasteriseFactor, rasteriseScaleThreshold, unitWidth } from '../../../utils/constants';
 import ArmyIcon from '../../../assets/icons/ArmyIcon.svg?react';
 import FleetIcon from '../../../assets/icons/FleetIcon.svg?react';
+import ArmyIconRaw from '../../../assets/icons/ArmyIcon.svg?raw';
+import FleetIconRaw from '../../../assets/icons/FleetIcon.svg?raw';
 
 type UnitIconProps = {
   unit: Unit;
   scaleFactor?: number;
   variant?: 'world' | 'overlay';
+};
+
+export const rasteriseUnitIcon = (
+  imageCache: Map<string, Promise<CanvasImageSource>>,
+  { unit, scaleFactor = 1, variant = 'world' }: UnitIconProps,
+  left: number,
+  bottom: number,
+  canvas: HTMLCanvasElement,
+  context: CanvasRenderingContext2D,
+  onComplete: () => void,
+) => {
+  const rasterAdjustment = rasteriseScaleThreshold * rasteriseFactor;
+
+  const isWorldVariant = variant === 'world';
+  let svg = unit.type === UnitType.Army ? ArmyIconRaw : FleetIconRaw;
+
+  const width = unitWidth * scaleFactor * rasterAdjustment;
+  const margin = isWorldVariant ? -width / 2 : 0;
+
+  // When drawing to canvas, CSS won't be applied, we'll need to apply the same effects manually.
+  const computedStyle = window.getComputedStyle(canvas);
+
+  let regionColour = getNationColour(unit.owner);
+  regionColour = regionColour.replace('var(', '').replace(')', '');
+  regionColour = computedStyle.getPropertyValue(regionColour);
+
+  const drawImage = (image: CanvasImageSource) => {
+    context.drawImage(
+      image,
+      left * rasterAdjustment + margin,
+      canvas.height - bottom * rasterAdjustment + margin,
+      width,
+      width,
+    );
+    onComplete();
+  };
+
+  const cacheKey = `uniticon|${unit.type}|${regionColour}`;
+  const cachedImage = imageCache.get(cacheKey);
+  if (cachedImage !== undefined) {
+    cachedImage.then(drawImage);
+  } else {
+    // Apply the SVG colour attribute.
+    svg = svg.replace('"currentColor"', `"${regionColour}"`);
+
+    // Apply CSS rules for fonts.
+    const svgDoc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+    svgDoc
+      .querySelectorAll('text')
+      .forEach((e) => e.setAttribute('font-family', 'ui-sans-serif, system-ui, sans-serif'));
+    svg = new XMLSerializer().serializeToString(svgDoc);
+
+    // Create a URL we can load as the image source.
+    const blob = new Blob([svg], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const image = new Image();
+    image.src = url;
+    const promise = new Promise<CanvasImageSource>((resolve) => {
+      image.onload = async () => {
+        URL.revokeObjectURL(url);
+        resolve(image);
+        drawImage(image);
+      };
+    });
+    imageCache.set(cacheKey, promise);
+  }
 };
 
 const UnitIcon = ({ unit, scaleFactor = 1, variant = 'world' }: UnitIconProps) => {

--- a/client/src/hooks/useRegionSvg.tsx
+++ b/client/src/hooks/useRegionSvg.tsx
@@ -1,182 +1,44 @@
 import { SVGProps } from 'react';
-import ADR from '../assets/map/ADR.svg?react';
-import AEG from '../assets/map/AEG.svg?react';
-import Alb from '../assets/map/Alb.svg?react';
-import Ank from '../assets/map/Ank.svg?react';
-import Apu from '../assets/map/Apu.svg?react';
-import Arm from '../assets/map/Arm.svg?react';
-import BAL from '../assets/map/BAL.svg?react';
-import BAR from '../assets/map/BAR.svg?react';
-import Bel from '../assets/map/Bel.svg?react';
-import Ber from '../assets/map/Ber.svg?react';
-import BLA from '../assets/map/BLA.svg?react';
-import Boh from '../assets/map/Boh.svg?react';
-import BOT from '../assets/map/BOT.svg?react';
-import Bre from '../assets/map/Bre.svg?react';
-import Bud from '../assets/map/Bud.svg?react';
-import BulE from '../assets/map/Bul_E.svg?react';
-import BulS from '../assets/map/Bul_S.svg?react';
-import Bur from '../assets/map/Bur.svg?react';
-import Cly from '../assets/map/Cly.svg?react';
-// Can't name a file 'Con' on Windows...thanks Tom Scott...
-import Con from '../assets/map/Con_.svg?react';
-import Den from '../assets/map/Den.svg?react';
-import EAS from '../assets/map/EAS.svg?react';
-import Edi from '../assets/map/Edi.svg?react';
-import ENG from '../assets/map/ENG.svg?react';
-import Fin from '../assets/map/Fin.svg?react';
-import Gal from '../assets/map/Gal.svg?react';
-import Gas from '../assets/map/Gas.svg?react';
-import Gre from '../assets/map/Gre.svg?react';
-import HEL from '../assets/map/HEL.svg?react';
-import Hol from '../assets/map/Hol.svg?react';
-import ION from '../assets/map/ION.svg?react';
-import IRI from '../assets/map/IRI.svg?react';
-import Kie from '../assets/map/Kie.svg?react';
-import Lon from '../assets/map/Lon.svg?react';
-import Lvn from '../assets/map/Lvn.svg?react';
-import Lvp from '../assets/map/Lvp.svg?react';
-import LYO from '../assets/map/LYO.svg?react';
-import MAO from '../assets/map/MAO.svg?react';
-import Mar from '../assets/map/Mar.svg?react';
-import Mos from '../assets/map/Mos.svg?react';
-import Mun from '../assets/map/Mun.svg?react';
-import Naf from '../assets/map/Naf.svg?react';
-import NAO from '../assets/map/NAO.svg?react';
-import Nap from '../assets/map/Nap.svg?react';
-import NTH from '../assets/map/NTH.svg?react';
-import NWG from '../assets/map/NWG.svg?react';
-import Nwy from '../assets/map/Nwy.svg?react';
-import Par from '../assets/map/Par.svg?react';
-import Pic from '../assets/map/Pic.svg?react';
-import Pie from '../assets/map/Pie.svg?react';
-import Por from '../assets/map/Por.svg?react';
-import Pru from '../assets/map/Pru.svg?react';
-import Rom from '../assets/map/Rom.svg?react';
-import Ruh from '../assets/map/Ruh.svg?react';
-import Rum from '../assets/map/Rum.svg?react';
-import Ser from '../assets/map/Ser.svg?react';
-import Sev from '../assets/map/Sev.svg?react';
-import Sil from '../assets/map/Sil.svg?react';
-import SKA from '../assets/map/SKA.svg?react';
-import Smy from '../assets/map/Smy.svg?react';
-import SpaN from '../assets/map/Spa_N.svg?react';
-import SpaS from '../assets/map/Spa_S.svg?react';
-import StpN from '../assets/map/Stp_N.svg?react';
-import StpS from '../assets/map/Stp_S.svg?react';
-import Swe from '../assets/map/Swe.svg?react';
-import Syr from '../assets/map/Syr.svg?react';
-import Tri from '../assets/map/Tri.svg?react';
-import Tun from '../assets/map/Tun.svg?react';
-import Tus from '../assets/map/Tus.svg?react';
-import Tyr from '../assets/map/Tyr.svg?react';
-import TYS from '../assets/map/TYS.svg?react';
-import Ukr from '../assets/map/Ukr.svg?react';
-import Ven from '../assets/map/Ven.svg?react';
-import Vie from '../assets/map/Vie.svg?react';
-import Wal from '../assets/map/Wal.svg?react';
-import War from '../assets/map/War.svg?react';
-import WES from '../assets/map/WES.svg?react';
-import Yor from '../assets/map/Yor.svg?react';
 
-const useRegionSvg = (id: string) =>
-  ({
-    ADR,
-    AEG,
-    Alb,
-    Ank,
-    Apu,
-    Arm,
-    BAL,
-    BAR,
-    Bel,
-    Ber,
-    BLA,
-    Boh,
-    BOT,
-    Bre,
-    Bud,
-    Bul_E: BulE,
-    Bul_S: BulS,
-    Bul: (props: SVGProps<SVGSVGElement>) => (
-      <>
-        <BulE {...props} />
-        <BulS {...props} />
-      </>
-    ),
-    Bur,
-    Cly,
-    Con,
-    Den,
-    EAS,
-    Edi,
-    ENG,
-    Fin,
-    Gal,
-    Gas,
-    Gre,
-    HEL,
-    Hol,
-    ION,
-    IRI,
-    Kie,
-    Lon,
-    Lvn,
-    Lvp,
-    LYO,
-    MAO,
-    Mar,
-    Mos,
-    Mun,
-    Naf,
-    NAO,
-    Nap,
-    NTH,
-    NWG,
-    Nwy,
-    Par,
-    Pic,
-    Pie,
-    Por,
-    Pru,
-    Rom,
-    Ruh,
-    Rum,
-    Ser,
-    Sev,
-    Sil,
-    SKA,
-    Smy,
-    Spa_N: SpaN,
-    Spa_S: SpaS,
-    Spa: (props: SVGProps<SVGSVGElement>) => (
-      <>
-        <SpaN {...props} />
-        <SpaS {...props} />
-      </>
-    ),
-    Stp_N: StpN,
-    Stp_S: StpS,
-    Stp: (props: SVGProps<SVGSVGElement>) => (
-      <>
-        <StpN {...props} />
-        <StpS {...props} />
-      </>
-    ),
-    Swe,
-    Syr,
-    Tri,
-    Tun,
-    Tus,
-    Tyr,
-    TYS,
-    Ukr,
-    Ven,
-    Vie,
-    Wal,
-    War,
-    WES,
-    Yor,
-  })[id];
+const getSvgs = <T extends unknown>(input: Record<string, T>, id: string) => {
+  let lookup = [id];
+  if (id === 'Con')
+    lookup = ['Con_']; // Can't name a file 'Con' on Windows...thanks Tom Scott...
+  else if (id === 'Bul') lookup = ['Bul_E', 'Bul_S'];
+  else if (id === 'Spa') lookup = ['Spa_N', 'Spa_S'];
+  else if (id === 'Stp') lookup = ['Stp_N', 'Stp_S'];
+  const svgs = lookup.map((l) => ({ svg: input[`../assets/map/${l}.svg`], key: l }));
+  if (svgs.some((svg) => svg === undefined))
+    throw new Error(`Failed region svg lookup for id ${id} (${lookup})`);
 
-export default useRegionSvg;
+  return svgs;
+};
+
+const reactSvgs = import.meta.glob<
+  React.FunctionComponent<React.ComponentProps<'svg'> & { title?: string }>
+>('../assets/map/*.svg', {
+  eager: true,
+  query: '?react',
+  import: 'default',
+});
+
+export const useRegionSvg = (id: string) => {
+  const svgs = getSvgs(reactSvgs, id);
+
+  if (svgs.length === 1) return svgs[0].svg;
+  return (props: SVGProps<SVGSVGElement>) => (
+    <>
+      {svgs.map((x) => (
+        <x.svg key={x.key} {...props} />
+      ))}
+    </>
+  );
+};
+
+const rawSvgs = import.meta.glob<string>('../assets/map/*.svg', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+});
+
+export const getRegionSvgRaw = (id: string) => getSvgs(rawSvgs, id).map((x) => x.svg);

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -17,6 +17,15 @@ export const orderArrowStartSeparation = 20;
 export const orderArrowEndSeparation = 10;
 export const pastTurnOpacity = 0.6;
 
+// Enable showing maps as rasterised images instead of SVGs. Improves UI responsiveness when zoomed out, but disables interactivity.
+export const rasteriseEnabled = true;
+// At what zoom level under which we display the images instead of the SVGs.
+export const rasteriseScaleThreshold = 0.2;
+// Size factor of the generated image at the threshold. 1 generates full resolution, 0.5 would be half resolution. Larger sizes improve quality, smaller reduces memory usage.
+export const rasteriseFactor = 1;
+// true = show SVGs as a fallback whilst the rasters generate; false = show empty map whilst rasters generate.
+export const rasteriseDisplayFallback = true;
+
 // API
 
 export const refetchInterval = 2000;


### PR DESCRIPTION
Fixes #31

Currently when zoomed out in the client with many boards visible, scrolling performance is poor. The large number of SVGs visible in the DOM tanks the browser's rendering performance.

To tackle this, introduce a new map-rasterization mode which caches the map image onto a canvas element. Introduce a policy that when zoomed out sufficiently, we remove the SVGs elements from the DOM and instead display the canvas element.

This greatly improves scrolling performance when zoomed out, as the browser has fewer DOM elements to deal with. The downside is that inputting orders is impossible until zooming back in Since users are likely to zoom in to give the required fidelity for clicking regions to input orders, this seems like a reasonable policy. But others policies are possible.

Code-wise there is a penalty in that we need to create parallel code paths to render elements to a canvas, as well as generating elements for React.

----

This is quite heavy in terms of extra code required, but I'll provide it in case anybody wants to mess with it or can otherwise streamline it.

Test case: Open any large game and zoom out. With this PR, once the map images have loaded, you can smoothly pan the map around. Previously it would be laggy. Here's an example:

https://github.com/user-attachments/assets/f3e8efe2-37db-43eb-8809-b80227d3bf94

`rasterizeDisplayFallback = false` means you'll be able to see the maps load in when zoomed out. You can also set `rasterizeDisplayFallback = true` which means we'll display the SVGs instead until the maps load in. That provides a more seamless visual experience whilst loading is happening, and you'll still get the performance benefits once everything has finished loading.

Example with the maps partially loaded:
![image](https://github.com/user-attachments/assets/844b3f3f-7b79-49e7-8575-7cbde7ec9dc9)

Now let's look at the comparison, here we are at zoom just above 0.6:
![image](https://github.com/user-attachments/assets/cdb37c27-b36d-40f4-a649-1ca8f1b7fa6e)

Then just under 0.6, at which point the image is used instead:
![image](https://github.com/user-attachments/assets/c52b58cf-bf8e-4bff-989f-2290305f07cc)

`rasterizeScaleThreshold` can be used to change where this transition occurs. The `rasterizeSize` settings controls the image quality of these snapshots, you can render to larger images for better quality, but it costs more memory to keep around.