### PR TITLE
Reduce input lag on the client.

### DIFF
--- a/client/src/components/user-interface/PlayerList.tsx
+++ b/client/src/components/user-interface/PlayerList.tsx
@@ -3,24 +3,22 @@ import Nation from '../../types/enums/nation';
 import colours from '../../utils/colours';
 import WorldContext from '../context/WorldContext';
 import GameDetails from './GameDetails';
-import { getActiveBoards } from '../../types/board';
 import { filterUnique } from '../../utils/listUtils';
 import PlayerListItem from './PlayerListItem';
 
 const PlayerList = () => {
-  const { world } = useContext(WorldContext);
+  const { world, boardState } = useContext(WorldContext);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [expandedPlayers, setExpandedPlayers] = useState<Nation[]>([]);
 
-  if (!world) return null;
+  if (!world || !boardState) return null;
   const { winner } = world;
 
-  const activeBoards = getActiveBoards(world.boards);
   const playerCentres = Object.values(Nation)
     .map((nation) => ({
       player: nation,
       centres: filterUnique(
-        activeBoards.flatMap((board) =>
+        boardState.activeBoards.flatMap((board) =>
           Object.keys(board.centres)
             .filter((region) => board.centres[region] === nation)
             .sort(),

--- a/client/src/components/world/boards/Board.tsx
+++ b/client/src/components/world/boards/Board.tsx
@@ -38,10 +38,8 @@ const Board = ({ board, winner, isActive }: BoardProps) => {
         margin: boardSeparation / 2,
       }}
     >
-      <div
-        className='rounded-xl'
-        style={{ backgroundColor: colours.boardBackground }}
-      >
+      <div className="rounded-xl" style={{ backgroundColor: colours.boardBackground }}>
+        <p className="text-md absolute left-8 top-1 z-10">{getBoardName(board)}</p>
         <div
           className="relative rounded-xl"
           style={{
@@ -55,11 +53,10 @@ const Board = ({ board, winner, isActive }: BoardProps) => {
             boxShadow: winner && isActive ? `0px 0px 100px 50px ${getNationColour(winner)}` : '',
           }}
         >
-          <p className="text-md -mt-7">{getBoardName(board)}</p>
           <Map board={board} />
           {!canMove && (
             <div
-              className="absolute w-full h-full z-10"
+              className="absolute w-full h-full top-0 z-10"
               style={{
                 backgroundColor: colours.boardBackground,
                 opacity: 1 - pastTurnOpacity,

--- a/client/src/components/world/boards/Map.tsx
+++ b/client/src/components/world/boards/Map.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import Board from '../../../types/board';
 import Region from './Region';
 import regions from '../../../data/regions';
@@ -19,13 +19,58 @@ const Map = ({ board, isShowingCoasts = false }: MapProps) => {
   const { world } = useContext(WorldContext);
   const { currentMode, currentOrder } = useContext(OrderEntryContext);
 
-  return (
-    <div className="mt-1">
-      {Object.keys(regions).map((region) => {
-        const baseRegion = region.split('_')[0];
-        const isCoast = region !== baseRegion;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
 
-        if (!isCoast) {
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => setIsVisible(entry.isIntersecting));
+    });
+    const { current } = containerRef;
+    if (current) observer.observe(current);
+    return () => {
+      if (current) observer.unobserve(current);
+    };
+  });
+
+  return (
+    <div className="w-full h-full" ref={containerRef}>
+      {isVisible &&
+        Object.keys(regions).map((region) => {
+          const baseRegion = region.split('_')[0];
+          const isCoast = region !== baseRegion;
+
+          if (!isCoast) {
+            return (
+              <Region
+                key={region}
+                id={region}
+                timeline={board.timeline}
+                year={board.year}
+                phase={board.phase}
+                owner={board.centres[region]}
+                unit={board.units[region]}
+              />
+            );
+          }
+
+          const hasArmy = board.units[baseRegion] !== undefined;
+          const hasFleet = board.units[region] !== undefined;
+
+          const showCoast = {
+            [InputMode.None]: hasFleet || (board.phase === Phase.Winter && !hasArmy),
+            [InputMode.Hold]: hasFleet,
+            [InputMode.Move]: currentOrder?.unit?.type === UnitType.Fleet,
+            [InputMode.Support]:
+              currentOrder?.$type === OrderType.Support &&
+              ((!currentOrder.supportLocation && hasFleet) ||
+                (currentOrder.supportLocation !== null &&
+                  findUnit(world, currentOrder.supportLocation)?.type === UnitType.Fleet)),
+            [InputMode.Convoy]: hasFleet,
+            [InputMode.Build]: true,
+            [InputMode.Disband]: hasFleet,
+          }[currentMode];
+
           return (
             <Region
               key={region}
@@ -33,42 +78,12 @@ const Map = ({ board, isShowingCoasts = false }: MapProps) => {
               timeline={board.timeline}
               year={board.year}
               phase={board.phase}
-              owner={board.centres[region]}
+              owner={board.centres[baseRegion]}
               unit={board.units[region]}
+              isVisible={showCoast || isShowingCoasts}
             />
           );
-        }
-
-        const hasArmy = board.units[baseRegion] !== undefined;
-        const hasFleet = board.units[region] !== undefined;
-
-        const showCoast = {
-          [InputMode.None]: hasFleet || (board.phase === Phase.Winter && !hasArmy),
-          [InputMode.Hold]: hasFleet,
-          [InputMode.Move]: currentOrder?.unit?.type === UnitType.Fleet,
-          [InputMode.Support]:
-            currentOrder?.$type === OrderType.Support &&
-            ((!currentOrder.supportLocation && hasFleet) ||
-              (currentOrder.supportLocation !== null &&
-                findUnit(world, currentOrder.supportLocation)?.type === UnitType.Fleet)),
-          [InputMode.Convoy]: hasFleet,
-          [InputMode.Build]: true,
-          [InputMode.Disband]: hasFleet,
-        }[currentMode];
-
-        return (
-          <Region
-            key={region}
-            id={region}
-            timeline={board.timeline}
-            year={board.year}
-            phase={board.phase}
-            owner={board.centres[baseRegion]}
-            unit={board.units[region]}
-            isVisible={showCoast || isShowingCoasts}
-          />
-        );
-      })}
+        })}
     </div>
   );
 };

--- a/client/src/hooks/useSetAvailableInputModes.tsx
+++ b/client/src/hooks/useSetAvailableInputModes.tsx
@@ -4,22 +4,22 @@ import InputMode from '../types/enums/inputMode';
 import { OrderEntryActionType } from '../types/context/orderEntryAction';
 import OrderEntryContext from '../components/context/OrderEntryContext';
 import WorldContext from '../components/context/WorldContext';
-import { getActiveBoards } from '../types/board';
 
 const useSetAvailableInputModes = () => {
-  const { world, isLoading, error } = useContext(WorldContext);
+  const { world, isLoading, error, boardState } = useContext(WorldContext);
   const { dispatch } = useContext(OrderEntryContext);
 
-  const boards = world && !isLoading && !error ? world.boards : [];
+  const activeBoardsOrEmpty =
+    world && !isLoading && !error && boardState?.activeBoards ? boardState.activeBoards : [];
   const winner = world?.winner;
 
-  const activeBoards = getActiveBoards(boards);
-
-  const hasRetreats = activeBoards.some((board) =>
+  const hasRetreats = activeBoardsOrEmpty.some((board) =>
     Object.values(board.units).some((unit) => unit.mustRetreat),
   );
-  const hasMajorBoard = !winner && activeBoards.some((board) => board.phase !== Phase.Winter);
-  const hasMinorBoard = !winner && activeBoards.some((board) => board.phase === Phase.Winter);
+  const hasMajorBoard =
+    !winner && activeBoardsOrEmpty.some((board) => board.phase !== Phase.Winter);
+  const hasMinorBoard =
+    !winner && activeBoardsOrEmpty.some((board) => board.phase === Phase.Winter);
 
   useEffect(() => {
     const retreatModes = [InputMode.Move, InputMode.Disband];


### PR DESCRIPTION
Fixes #30

When a region is selected on the client for an order, all Regions are re-rendered. useSelectLocation is quite expensive because each region will calculate getActiveBoards and isRetreatTurn.

We can cache these in the WorldContext instead, so each Region can reuse a single result rather than performing redundant work to re-calculate it per-region.

This reduces the re-render cost of Region significantly. Whilst this doesn't solve the input lag issue, it does help reduce it.

----

Profile before, notice `useSelectLocation` is a large portion of the time to render a Region.
![image](https://github.com/user-attachments/assets/bab94b3d-bf93-4c77-a208-6d1ea132f87f)

After, `useSelectLocation` is now cheap.
![image](https://github.com/user-attachments/assets/ecf46402-0829-4c36-a87d-9c80e48ccc93)

----

When a region is selected on the client for an order, all Regions are re-rendered. This is expensive.

Use an IntersectionObserver on each Map, and don't render the Regions when the map is offscreen. This reduces the rendering workload from all maps, to only onscreen maps.

This results in occasional empty maps when panning since regions will need a moment to load in and not be available right away, however it fixes the input lag issue as only rendering changes for onscreen elements and not all elements keeps the delay to an acceptable level.