### PR TITLE
Wrap database queries in transactions to prevent concurrency issues.

### DIFF
--- a/server/Controllers/GameController.cs
+++ b/server/Controllers/GameController.cs
@@ -1,4 +1,5 @@
 using Enums;
+using Exceptions;
 using Mappers;
 using Microsoft.AspNetCore.Mvc;
 using Models;
@@ -66,12 +67,12 @@ public class GameController(
                 return Ok(new Game(game.Id, game.HasStrictAdjacencies, chosenPlayer));
             }
         }
-        catch (KeyNotFoundException)
+        catch (GameNotFoundException)
         {
             logger.LogError("Attempted to join non-existent game {GameId}", gameId);
             return NotFound($"No game with ID {gameId} found");
         }
-        catch (InvalidOperationException error)
+        catch (GameInvalidException error)
         {
             logger.LogWarning("Failed to join game {GameId}", gameId);
             return BadRequest(error.Message);
@@ -89,7 +90,7 @@ public class GameController(
             var world = await worldRepository.GetWorld(gameId);
             return Ok(entityMapper.MapWorld(world, player));
         }
-        catch (KeyNotFoundException)
+        catch (GameNotFoundException)
         {
             logger.LogWarning("Failed to find world with ID {GameId}", gameId);
             return NotFound($"No world with game ID {gameId} found");
@@ -107,7 +108,7 @@ public class GameController(
             var iteration = await worldRepository.GetIteration(gameId);
             return Ok(iteration);
         }
-        catch (KeyNotFoundException)
+        catch (GameNotFoundException)
         {
             logger.LogWarning("Failed to find world with ID {GameId}", gameId);
             return NotFound($"No world with game ID {gameId} found");
@@ -140,7 +141,7 @@ public class GameController(
             await worldRepository.AddOrders(gameId, players, mappedOrders);
             return Ok();
         }
-        catch (KeyNotFoundException)
+        catch (GameNotFoundException)
         {
             logger.LogWarning("Failed to find world with ID {GameId}", gameId);
             return NotFound($"No world with game ID {gameId} found");

--- a/server/Exceptions/GameInvalidException.cs
+++ b/server/Exceptions/GameInvalidException.cs
@@ -1,0 +1,8 @@
+﻿namespace Exceptions;
+
+[Serializable]
+public class GameInvalidException : Exception
+{
+    public GameInvalidException() { }
+    public GameInvalidException(string message) : base(message) { }
+}

--- a/server/Exceptions/GameNotFoundException.cs
+++ b/server/Exceptions/GameNotFoundException.cs
@@ -1,0 +1,7 @@
+﻿namespace Exceptions;
+
+[Serializable]
+public class GameNotFoundException : Exception
+{
+    public GameNotFoundException() { }
+}


### PR DESCRIPTION
- Use AsNoTracking on read-only queries to improve performance, GetIteration also avoids tracking by not returning an entity.
- Create dedicated GameNotFoundException and GameInvalidException, to avoid try-catch blocks in the controller triggering on other bugs, e.g. for a legitimate KeyNotFoundException elsewhere.