### PR TITLE
Add ability to load saved game files.

### DIFF
--- a/client/src/api/routes.ts
+++ b/client/src/api/routes.ts
@@ -3,6 +3,7 @@ const baseUrl = import.meta.env.VITE_SERVER_URL;
 const routes = {
   createGame: () => `${baseUrl}/game`,
   joinGame: (gameId: number) => `${baseUrl}/game/${gameId}/players`,
+  loadGame: () => `${baseUrl}/game/load`,
   getWorld: (gameId: number) => `${baseUrl}/game/${gameId}`,
   submitOrders: (gameId: number) => `${baseUrl}/game/${gameId}/orders`,
   getIteration: (gameId: number) => `${baseUrl}/game/${gameId}/iteration`,

--- a/client/src/assets/icons/DownloadIcon.svg
+++ b/client/src/assets/icons/DownloadIcon.svg
@@ -1,5 +1,5 @@
 <svg width="16" height="16">
-  <path d="M 2,14 14,14" stroke="black" stroke-linecap="round"/>
-  <path d="M 8.5,2 8.5,10" stroke="black" stroke-linecap="round"/>
-  <path d="M 6,6 8.5,10 11,6 8.5,10" stroke="black" stroke-linecap="round"/>
+  <path d="M 2,14 14,14" stroke="currentcolor" stroke-linecap="round"/>
+  <path d="M 8.5,2 8.5,10" stroke="currentcolor" stroke-linecap="round"/>
+  <path d="M 6,6 8.5,10 11,6 8.5,10" stroke="currentcolor" stroke-linecap="round"/>
 </svg>

--- a/client/src/components/SetupRoot.tsx
+++ b/client/src/components/SetupRoot.tsx
@@ -3,6 +3,7 @@ import LandingPage from './pages/LandingPage';
 import SetupViewOption from '../types/enums/setupViewOption';
 import NewGamePage from './pages/NewGamePage';
 import JoinGamePage from './pages/JoinGamePage';
+import LoadGamePage from './pages/LoadGamePage';
 
 const SetupRoot = () => {
   const [option, setOption] = useState(SetupViewOption.None);
@@ -12,6 +13,7 @@ const SetupRoot = () => {
       {option === SetupViewOption.None && <LandingPage setViewOption={setOption} />}
       {option === SetupViewOption.New && <NewGamePage setViewOption={setOption} />}
       {option === SetupViewOption.Join && <JoinGamePage setViewOption={setOption} />}
+      {option === SetupViewOption.Load && <LoadGamePage setViewOption={setOption} />}
     </div>
   );
 };

--- a/client/src/components/pages/LandingPage.tsx
+++ b/client/src/components/pages/LandingPage.tsx
@@ -21,6 +21,11 @@ const LandingPage = ({ setViewOption }: LandingPageProps) => (
           minWidth={184}
           onClick={() => setViewOption(SetupViewOption.Join)}
         />
+        <Button
+          text="Load Game"
+          minWidth={184}
+          onClick={() => setViewOption(SetupViewOption.Load)}
+        />
       </div>
       <LinkGroup
         heading="Created by"

--- a/client/src/components/pages/LoadGamePage.tsx
+++ b/client/src/components/pages/LoadGamePage.tsx
@@ -1,0 +1,68 @@
+import { useContext, useState } from 'react';
+import Nation from '../../types/enums/nation';
+import SetupViewOption from '../../types/enums/setupViewOption';
+import Button from '../user-interface/common/Button';
+import NationSelect from '../user-interface/NationSelect';
+import GameContext from '../context/GameContext';
+import Error from '../user-interface/common/Error';
+import Select from '../user-interface/common/Select';
+
+type LoadGamePageProps = {
+  setViewOption: (option: SetupViewOption) => void;
+};
+
+const LoadGamePage = ({ setViewOption }: LoadGamePageProps) => {
+  const { loadGame, exitGame, isLoading, error } = useContext(GameContext);
+
+  const [isSandbox, setIsSandbox] = useState(false);
+  const [player, setPlayer] = useState<Nation>();
+  const [file, setFile] = useState<File | null>(null);
+
+  const onLoadPressed = () => loadGame(isSandbox, player ?? null, file!);
+
+  const onFileChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      setFile(e.target.files[0]);
+    }
+  };
+
+  const onBackPressed = () => {
+    exitGame();
+    setViewOption(SetupViewOption.None);
+  };
+
+  return (
+    <div className="flex flex-col w-screen h-screen items-center gap-4 pt-24">
+      <img alt="Logo" src="./logo.png" className="w-64 h-64 mb-8" />
+      <Select
+        options={[
+          {
+            value: 'false',
+            text: 'Normal',
+          },
+          {
+            value: 'true',
+            text: 'Sandbox',
+          },
+        ]}
+        setValue={(value) => setIsSandbox(value === 'true')}
+        selectedValue={isSandbox ? 'true' : 'false'}
+      />
+      {!isSandbox && <NationSelect selectedNation={player} setSelectedNation={setPlayer} />}
+      <input className="w-64 pr-4" type="file" accept="application/json" onChange={onFileChanged} />
+      <Button
+        text="Load"
+        minWidth={256}
+        onClick={onLoadPressed}
+        isBusy={isLoading}
+        isDisabled={file === null}
+      />
+      {error && <Error error={error} />}
+      <div className="absolute bottom-10">
+        <Button text="Back" minWidth={96} onClick={onBackPressed} />
+      </div>
+    </div>
+  );
+};
+
+export default LoadGamePage;

--- a/client/src/components/user-interface/GameDetails.tsx
+++ b/client/src/components/user-interface/GameDetails.tsx
@@ -5,6 +5,8 @@ import CopyIcon from '../../assets/icons/CopyIcon.svg?react';
 import DownloadIcon from '../../assets/icons/DownloadIcon.svg?react';
 import GameContext from '../context/GameContext';
 import WorldContext from '../context/WorldContext';
+import SaveFile from '../../types/saveFile';
+import { OrderStatus } from '../../types/order';
 
 const GameDetails = () => {
   const { game } = useContext(GameContext);
@@ -17,7 +19,18 @@ const GameDetails = () => {
 
   const adjacencySettingText = `Adjacencies: ${game.hasStrictAdjacencies ? 'Strict' : 'Loose'}`;
 
-  const gameJsonFile = URL.createObjectURL(new Blob([JSON.stringify(world, null, 2)]));
+  let gameJsonFile: string | null = null;
+  if (world) {
+    const saveFile: SaveFile = {
+      hasStrictAdjacencies: game.hasStrictAdjacencies,
+      iteration: world.iteration,
+      orders: world.orders.filter(
+        (o) => o.status !== OrderStatus.New && o.status !== OrderStatus.RetreatNew,
+      ),
+    };
+
+    gameJsonFile = URL.createObjectURL(new Blob([JSON.stringify(saveFile, null, 2)]));
+  }
 
   return (
     <div
@@ -36,17 +49,19 @@ const GameDetails = () => {
         >
           <CopyIcon />
         </button>
-        <a
-          aria-label="Download game as JSON"
-          className="opacity-30 hover:opacity-70 ml-6"
-          href={gameJsonFile}
-          download="game.json"
-          target="_blank"
-          rel="noreferrer"
-          title="Download game as JSON"
-        >
-          <DownloadIcon />
-        </a>
+        {gameJsonFile && (
+          <a
+            aria-label="Download game as JSON"
+            className="opacity-30 hover:opacity-70 ml-6"
+            href={gameJsonFile}
+            download="game.json"
+            target="_blank"
+            rel="noreferrer"
+            title="Download game as JSON"
+          >
+            <DownloadIcon />
+          </a>
+        )}
       </div>
       <p
         className="font-bold text-lg"

--- a/client/src/hooks/api/useLoadGame.tsx
+++ b/client/src/hooks/api/useLoadGame.tsx
@@ -1,0 +1,36 @@
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import Game from '../../types/game';
+import Nation from '../../types/enums/nation';
+import routes from '../../api/routes';
+
+type LoadRequest = {
+  isSandbox: boolean;
+  player: Nation | null;
+  file: File;
+};
+
+const loadGame = async ({ isSandbox, player, file }: LoadRequest): Promise<Game> => {
+  const route = routes.loadGame();
+  const formData = new FormData();
+  formData.append('isSandbox', isSandbox.toString());
+  formData.append('player', player?.toString() ?? '');
+  formData.append('file', file);
+  const config = {
+    headers: {
+      'content-type': 'multipart/form-data',
+    },
+  };
+  const response = await axios.post<Game>(route, formData, config);
+  return response.data;
+};
+
+const useLoadGame = () => {
+  const { mutate, data, ...rest } = useMutation({
+    mutationKey: ['loadGame'],
+    mutationFn: loadGame,
+  });
+  return { loadGame: mutate, game: data ?? null, ...rest };
+};
+
+export default useLoadGame;

--- a/client/src/types/context/gameState.ts
+++ b/client/src/types/context/gameState.ts
@@ -9,6 +9,7 @@ type GameState = {
     hasStrictAdjacencies: boolean,
   ) => Promise<void>;
   joinGame: (gameId: number, isSandbox: boolean, player: Nation | null) => Promise<void>;
+  loadGame: (isSandbox: boolean, player: Nation | null, file: File) => Promise<void>;
   exitGame: () => void;
   isLoading: boolean;
   error: Error | null;

--- a/client/src/types/enums/setupViewOption.ts
+++ b/client/src/types/enums/setupViewOption.ts
@@ -2,6 +2,7 @@ enum SetupViewOption {
   None = 'None',
   New = 'New',
   Join = 'Join',
+  Load = 'Load',
 }
 
 export default SetupViewOption;

--- a/client/src/types/saveFile.ts
+++ b/client/src/types/saveFile.ts
@@ -1,0 +1,9 @@
+import Order from './order';
+
+type SaveFile = {
+  hasStrictAdjacencies: boolean;
+  iteration: number;
+  orders: Order[];
+};
+
+export default SaveFile;

--- a/server/Models/Location.cs
+++ b/server/Models/Location.cs
@@ -8,4 +8,5 @@ public class Location(int timeline, int year, Phase phase, string region)
     public int Year { get; set; } = year;
     public Phase Phase { get; set; } = phase;
     public string Region { get; set; } = region;
+    public override string ToString() => $"({Timeline}, {Year}, {Phase}, {Region})";
 }

--- a/server/Models/Orders/Build.cs
+++ b/server/Models/Orders/Build.cs
@@ -4,4 +4,5 @@ namespace Models;
 
 public class Build(OrderStatus status, Unit unit, Location location) : Order(status, unit, location)
 {
+    public override string ToString() => $"Build {Location}: {Status}";
 }

--- a/server/Models/Orders/Convoy.cs
+++ b/server/Models/Orders/Convoy.cs
@@ -6,4 +6,5 @@ public class Convoy(OrderStatus status, Unit unit, Location location, Location d
 {
     public Location ConvoyLocation { get; set; } = convoyLocation;
     public Location Destination { get; set; } = destination;
+    public override string ToString() => $"Convoy {Location} from {ConvoyLocation} to {Destination}: {Status}";
 }

--- a/server/Models/Orders/Disband.cs
+++ b/server/Models/Orders/Disband.cs
@@ -4,4 +4,5 @@ namespace Models;
 
 public class Disband(OrderStatus status, Unit unit, Location location) : Order(status, unit, location)
 {
+    public override string ToString() => $"Disband {Location}: {Status}";
 }

--- a/server/Models/Orders/Hold.cs
+++ b/server/Models/Orders/Hold.cs
@@ -4,4 +4,5 @@ namespace Models;
 
 public class Hold(OrderStatus status, Unit unit, Location location) : Order(status, unit, location)
 {
+    public override string ToString() => $"Hold {Location}: {Status}";
 }

--- a/server/Models/Orders/Move.cs
+++ b/server/Models/Orders/Move.cs
@@ -5,4 +5,5 @@ namespace Models;
 public class Move(OrderStatus status, Unit unit, Location location, Location destination) : Order(status, unit, location)
 {
     public Location Destination { get; set; } = destination;
+    public override string ToString() => $"Move {Location} to {Destination}: {Status}";
 }

--- a/server/Models/Orders/Order.cs
+++ b/server/Models/Orders/Order.cs
@@ -14,4 +14,12 @@ public abstract class Order(OrderStatus status, Unit unit, Location location)
     public OrderStatus Status { get; set; } = status;
     public Unit Unit { get; set; } = unit;
     public Location Location { get; set; } = location;
+
+    public abstract override string ToString();
+
+    public bool IsRetreat() => Status
+        is OrderStatus.RetreatNew
+        or OrderStatus.RetreatSuccess
+        or OrderStatus.RetreatFailure
+        or OrderStatus.RetreatInvalid;
 }

--- a/server/Models/Orders/Support.cs
+++ b/server/Models/Orders/Support.cs
@@ -6,4 +6,5 @@ public class Support(OrderStatus status, Unit unit, Location location, Location 
 {
     public Location SupportLocation { get; set; } = supportLocation;
     public Location Destination { get; set; } = destination;
+    public override string ToString() => $"Support {Location} from {SupportLocation} to {Destination}: {Status}";
 }

--- a/server/Models/Requests/GameLoadRequest.cs
+++ b/server/Models/Requests/GameLoadRequest.cs
@@ -1,0 +1,5 @@
+﻿using Enums;
+
+namespace Models;
+
+public record GameLoadRequest(bool IsSandbox, Nation? Player, IFormFile File);

--- a/server/Models/Requests/SaveFile.cs
+++ b/server/Models/Requests/SaveFile.cs
@@ -1,0 +1,3 @@
+﻿namespace Models;
+
+public record SaveFile(bool HasStrictAdjacencies, int Iteration, Order[] Orders);

--- a/server/Repositories/GameRepository.cs
+++ b/server/Repositories/GameRepository.cs
@@ -20,7 +20,7 @@ public class GameRepository(ILogger<GameRepository> logger, GameContext context,
     {
         logger.LogInformation("Fetching game {Id}", id);
 
-        var game = await context.Games.FindAsync(id) ?? throw new GameNotFoundException();
+        var game = await context.Games.AsNoTracking().SingleOrDefaultAsync(g => g.Id == id) ?? throw new GameNotFoundException();
         return game;
     }
 


### PR DESCRIPTION
- There is an existing "Download game as JSON" button in the UI, reuse this but adjust the save format.
- Add an endpoint that accepts a upload of a previously saved JSON file. We create a fresh world and replay the orders over it.
- Add a new UI to load such a previously saved JSON file via this new endpoint, similar to creating a game.

Given the pragmatic reality that there is no single persistent online server, sharing games or analyzing them is somewhat difficult. By introducing the ability to load saved games, users can at least import interesting games into their local servers.

----

Possibly relevant for #41 (you can load the save, no need to do things by hand) , #17 (it's not an undo, but you could use the save to "restore from backup" into a new game).

To use this feature:
- Download a save file of your game *using this PR* - older save files are not compatible
![image](https://github.com/user-attachments/assets/2eb6f6b1-4203-41dd-8985-5b8e01c33137)
- Use the new "Load Game" button to upload the save file.
![image](https://github.com/user-attachments/assets/0e0c2803-8ac5-4b22-98bb-98ca77d2a9b1)
![image](https://github.com/user-attachments/assets/147a1de9-8e55-4ce1-86e7-0e0af7c88ac0)
- You'll join under a new game ID, with the save state loaded.