### PR TITLE
If the user toggles light/dark mode, regenerate rasterised map images.

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,11 +2,14 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import queryClient from './api/queryClient';
 import { GameContextProvider } from './components/context/GameContext';
 import AppRoot from './components/AppRoot';
+import { DarkModeContextContextProvider } from './components/context/DarkModeContext';
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <GameContextProvider>
-      <AppRoot />
+      <DarkModeContextContextProvider>
+        <AppRoot />
+      </DarkModeContextContextProvider>
     </GameContextProvider>
   </QueryClientProvider>
 );

--- a/client/src/components/AppRoot.tsx
+++ b/client/src/components/AppRoot.tsx
@@ -1,26 +1,15 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import GameContext from './context/GameContext';
 import SetupRoot from './SetupRoot';
 import { WorldContextProvider } from './context/WorldContext';
 import GameRoot from './GameRoot';
 import colours, { coloursVariables, lightColours, darkColours } from '../utils/colours';
 import { Colours } from '../utils/types';
+import DarkModeContext from './context/DarkModeContext';
 
 const AppRoot = () => {
   const { game } = useContext(GameContext);
-
-  const [isDarkMode, setIsDarkMode] = useState(false);
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    if (mediaQuery.matches) {
-      setIsDarkMode(true);
-    }
-
-    // Watch for changes to the user's preferred colour scheme
-    const listener = () => setIsDarkMode(mediaQuery.matches);
-    mediaQuery.addEventListener('change', listener);
-    return () => mediaQuery.removeEventListener('change', listener);
-  }, []);
+  const isDarkMode = useContext(DarkModeContext);
 
   const cssVariables = Object.entries(coloursVariables).reduce((acc, [key, value]) => {
     const colour = isDarkMode ? darkColours[key as keyof Colours] : lightColours[key as keyof Colours];

--- a/client/src/components/context/DarkModeContext.tsx
+++ b/client/src/components/context/DarkModeContext.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren, createContext, useEffect, useState } from 'react';
+
+const DarkModeContext = createContext(false);
+
+export const DarkModeContextContextProvider = ({ children }: PropsWithChildren) => {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    if (mediaQuery.matches) {
+      setIsDarkMode(true);
+    }
+
+    // Watch for changes to the user's preferred colour scheme
+    const listener = () => setIsDarkMode(mediaQuery.matches);
+    mediaQuery.addEventListener('change', listener);
+    return () => mediaQuery.removeEventListener('change', listener);
+  }, []);
+
+  return <DarkModeContext.Provider value={isDarkMode}>{children}</DarkModeContext.Provider>;
+};
+
+export default DarkModeContext;


### PR DESCRIPTION
Previously, when toggling this mode the CSS styles would be updated, but the images would remain in the previous colour mode. Therefore an incorrect map color scheme was visible when zoomed out. Now the images will be regenerated so the colour scheme matches again.

----

Bugs nobody will encounter in reality, but nice to fix the edge case anyway.