### PR TITLE
Adjudicate performance tweaks.

### DIFF
--- a/server/Adjudication/Evaluation/AdjustmentEvaluator.cs
+++ b/server/Adjudication/Evaluation/AdjustmentEvaluator.cs
@@ -15,6 +15,11 @@ public class AdjustmentEvaluator(World world, List<Order> activeOrders)
     {
         var boards = world.ActiveBoards.Where(b => b.Phase == Phase.Winter);
 
+        var activeBuildUnits = activeOrders
+            .OfType<Build>()
+            .Select(b => b.Unit)
+            .ToHashSet();
+
         foreach (var board in boards)
         {
             board.MightAdvance = true;
@@ -28,20 +33,18 @@ public class AdjustmentEvaluator(World world, List<Order> activeOrders)
 
             foreach (var nation in Constants.Nations)
             {
-                EvaluateBoardForNation(board, nation, boardBuilds, boardDisbands);
+                EvaluateBoardForNation(board, nation, boardBuilds, boardDisbands, activeBuildUnits);
             }
         }
     }
 
-    private void EvaluateBoardForNation(Board board, Nation nation, List<Build> boardBuilds, List<Disband> boardDisbands)
+    private void EvaluateBoardForNation(Board board, Nation nation, List<Build> boardBuilds, List<Disband> boardDisbands, HashSet<Unit> activeBuildUnits)
     {
         var nationBuilds = boardBuilds.Where(b => b.Unit.Owner == nation).ToList();
         var nationDisbands = boardDisbands.Where(d => d.Unit.Owner == nation).ToList();
 
         var centreCount = board.Centres.Count(c => c.Owner == nation);
-        var unitCount = board.Units.Count(u =>
-            !activeOrders.OfType<Build>().Any(o => o.Unit == u)
-            && u.Owner == nation);
+        var unitCount = board.Units.Count(u => u.Owner == nation && !activeBuildUnits.Contains(u));
 
         var adjustmentCount = centreCount - unitCount;
 

--- a/server/Adjudication/Evaluation/Evaluator.cs
+++ b/server/Adjudication/Evaluation/Evaluator.cs
@@ -74,6 +74,7 @@ public class Evaluator
         }
 
         var activeOrders = touchedOrdersFinder.GetTouchedOrders(newOrders, hasRetreats);
+        var boardsByLocation = world.Boards.ToDictionary(b => (b.Timeline, b.Year, b.Phase));
 
         foreach (var order in activeOrders)
         {
@@ -82,10 +83,12 @@ public class Evaluator
                 order.Status = OrderStatus.New;
             }
 
-            var touchedBoards = world.Boards.Where(b => order.TouchedLocations().Any(l => b.Contains(l))).ToList();
-            foreach (var board in touchedBoards)
+            foreach (var location in order.TouchedLocations())
             {
-                board.MightAdvance = true;
+                if (boardsByLocation.TryGetValue((location.Timeline, location.Year, location.Phase), out var touchedBoard))
+                {
+                    touchedBoard.MightAdvance = true;
+                }
             }
         }
 

--- a/server/Adjudication/Validation/AdjacencyValidator.cs
+++ b/server/Adjudication/Validation/AdjacencyValidator.cs
@@ -123,6 +123,14 @@ public class AdjacencyValidator(RegionMap regionMap, bool hasStrictAdjacencies)
         return CanTraverseConnection(unit, connection);
     }
 
+    public Location ParentLocation(Location location)
+    {
+        var region = regionMap.GetRegion(location.RegionId);
+        return region.Parent == null
+            ? location
+            : new Location { Timeline = location.Timeline, Year = location.Year, Phase = location.Phase, RegionId = region.Parent.Id };
+    }
+
     public bool EqualsOrIsRelated(Location location1, Location location2)
     {
         if (location1.Timeline != location2.Timeline ||


### PR DESCRIPTION
- AdjustmentEvaluator creates a lookup for active builds outside the loop.
- Evaluator creates a lookup for boards outside the loop.
- TouchedOrdersFinder creates a lookup for world orders outside the loop.

All of these scenarios avoid a quadratic-like runtime behaviour where every item from one collection is compared with every item from another. We fix them all with a lookup of some kind.

The last scenario is the most impactful as it removes the need to compare every order in the world with every active order. In order to make a valid lookup, we need a key that can be compared for equality. If we realise that EqualsOrIsRelated is comparing the parent regions of a location, we can use that as the key.

----

#55 runs through an entire game at once, which provided a useful way of testing the performance of adjudication at a larger scale. This allowed me to identify a couple more areas where a lookup provides an easy win. In particular I'm happy that I noticed we can in fact cache the lookup of `EqualsOrIsRelated` which wasn't obvious to me originally.

Comparing the performance before & after, the adjudication logic is about 3.5x faster and now largely inconsequential compared to the database traffic.

![image](https://github.com/user-attachments/assets/bb29fe26-0d05-4fe6-8e54-5e5ab683164a)

![image](https://github.com/user-attachments/assets/f0002fe5-6755-4f2e-be41-9b1f2e3b563a)