### PR TITLE
Validate only new retreats as retreats

### DIFF
--- a/server/Adjudication/Validation/Validator.cs
+++ b/server/Adjudication/Validation/Validator.cs
@@ -29,7 +29,7 @@ public class Validator
         this.adjacencyValidator = adjacencyValidator;
 
         nonRetreats = [.. world.Orders.Where(o => o.NeedsValidation && !o.Unit.MustRetreat)];
-        retreats = [.. world.Orders.Where(o => o.NeedsValidation && o.Unit.MustRetreat)];
+        retreats = [.. world.Orders.Where(o => o.Status is OrderStatus.RetreatNew && o.Unit.MustRetreat)];
 
         moves = [.. nonRetreats.OfType<Move>()];
         supports = [.. nonRetreats.OfType<Support>()];


### PR DESCRIPTION
This fixes a bug where supports were sometimes marked as RetreatInvalid, leading moves that had supported them to cause crashes. A similar issue can happen with convoys.

This may cause some more retreats to be rechosen than would have happened previously.