### PR TITLE
Retreats into units that failed to move should fail

### DIFF
--- a/server/Adjudication/Evaluation/RetreatEvaluator.cs
+++ b/server/Adjudication/Evaluation/RetreatEvaluator.cs
@@ -40,7 +40,7 @@ public class RetreatEvaluator(World world, List<Order> activeOrders, AdjacencyVa
         var supports = world.Orders.OfType<Support>();
         var convoys = world.Orders.OfType<Convoy>();
 
-        List<Order> stationaryOrders = [.. holds, .. supports, .. convoys, .. moves.Where(m => m.Status == OrderStatus.Invalid)];
+        List<Order> stationaryOrders = [.. holds, .. supports, .. convoys, .. moves.Where(m => m.Status is OrderStatus.Invalid or OrderStatus.Failure)];
 
         foreach (var retreat in retreats)
         {

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY . /app
 RUN dotnet build -c Release -o bin
 
-RUN dotnet tool install --global dotnet-ef
+RUN dotnet tool install --global dotnet-ef --version 9.0.11
 
 RUN echo "#!/bin/sh" >> /app/docker-entrypoint.sh \
   && echo "~/.dotnet/tools/dotnet-ef database update --context SqliteGameContext" >> /app/docker-entrypoint.sh \


### PR DESCRIPTION
If a unit is ordered to retreat into a province which had a unit which attempted to move but failed (while not being an invalid move), the game breaks. We encountered this in the game currently referred to as "T1S02 Holland", previously and provisionally "hibernation".

I've also fixed the version of dotnet-ef which is installed, since that was the easiest way to get the project building again.